### PR TITLE
Remove hipacloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,6 @@ Valar Mogulis，打工皆有失业。上班打工的最大风险是长期失业�
 > 创业公司风险高，请谨慎看待股权与期权的承诺
 
 - [Kikitrade](https://www.kikitrade.com/) (区块链金融，已A轮)
-- [黑帕云](https://hipacloud.com/)（创造无代码应用搭建平台，创始人陈金洲也曾创立金数据产品）
 - [庖丁科技](https://paodingai.com/)
 
 <details>


### PR DESCRIPTION
hipacloud has been acquired by ByteDance, Ref: https://hipacloud.com/blog/shutdown/